### PR TITLE
fix(create_tables): Don't try to import chimedb.setup

### DIFF
--- a/chimedb/core/__init__.py
+++ b/chimedb/core/__init__.py
@@ -99,4 +99,4 @@ from .orm import connect_database as connect
 from .orm import database_proxy as proxy
 from .connectdb import close
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
This avoids the following, which happens if an uninstalled chimedb
package is in the import path:

```
bash$ python
>>> import chimedb.core
>>> chimedb.core.orm.create_tables()
usage:  [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or:  --help [cmd1 cmd2 ...]
   or:  --help-commands
   or:  cmd --help

error: no commands supplied
bash$
```

which is the result of this function trying to import the `setup.py` it
finds in the base `chimedb` directory.  (Note the exit-to-shell).

We fix this by explicitly avoiding the import of `chimedb.setup`.

Since the infrastructure is there, I've also explicitly disabled the
import of chimedb.core, whose tables are already in scope, and
chimedb.config, which shouldn't ever define tables to create

Both an additional bell and an additional whistle have been added:
* an `ignore` parameter, which allows specifying other tables to not
create
* a `check` parameter, which will cause the function to print out the
tables it would create, without actually creating them

The function also now ensures that a read-write connection has been
made to the database (when check==False).