### PR TITLE
feat(core): test-safe mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ models for the tables in the database.  Packages which define tables include:
     index tables updated by alpenhorn
 * [chimedb.dataflag](https://github.com/chime-experiment/chimedb_dataflag):
     for data flags, and the associated `cdf` CLI
+* [chimedb.dataset](https://github.com/chime-experiment/chimedb_dataset):
+    for dataset tables updated by comet
 * [ch_util](https://bitbucket.org/chime/ch_util): for all other tables
 
 ## Connecting to the Database
@@ -106,6 +108,12 @@ Exceptions related to database operations (queries and updates):
 
     If `True`, re-establish a new connection to the database, even if
     one already exists.
+
+* `test_enable()`
+
+  Turn on test-safe mode.  For use during unit testing.  Turning on test-safe
+  mode prevents actually running tests on the production database.  See
+  `connectdb` for full details.
 
 ### Globals
 

--- a/chimedb/core/__init__.py
+++ b/chimedb/core/__init__.py
@@ -97,6 +97,6 @@ from .exceptions import (
 )
 from .orm import connect_database as connect
 from .orm import database_proxy as proxy
-from .connectdb import close
+from .connectdb import close, test_enable
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/test/test_test_enable.py
+++ b/test/test_test_enable.py
@@ -1,0 +1,161 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+import peewee as pw
+import chimedb.core as db
+from chimedb.core.orm import base_model
+
+
+class TestTable(base_model):
+    datum = pw.IntegerField()
+
+
+datum_value = 84
+
+
+class TestSqlite(unittest.TestCase):
+    """Test using test_enable() for testing"""
+
+    def setUp(self):
+        if "CHIMEDB_SQLITE" in os.environ:
+            del os.environ["CHIMEDB_SQLITE"]
+        if "CHIMEDBRC" in os.environ:
+            del os.environ["CHIMEDBRC"]
+        if "CHIMEDB_TEST_SQLITE" in os.environ:
+            del os.environ["CHIMEDB_TEST_SQLITE"]
+        if "CHIMEDB_TEST_RC" in os.environ:
+            del os.environ["CHIMEDB_TEST_RC"]
+
+    def test_chimedb_test_sqlite(self):
+        # Create an empty on-disk sqlite database
+        (fd, dbfile) = tempfile.mkstemp(text=True)
+        os.close(fd)
+
+        os.environ["CHIMEDB_TEST_SQLITE"] = dbfile
+
+        db.test_enable()
+
+        db.connect(read_write=True)
+        db.proxy.create_tables([TestTable])
+        TestTable.create(datum=datum_value)
+
+        # Did that work?
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        db.close()
+
+        # The on-disk sqlite database should not be empty anymore
+        stat = os.stat(dbfile)
+        self.assertNotEqual(stat.st_size, 0)
+
+    def test_chimedb_sqlite(self):
+        # Create an empty on-disk sqlite database that won't be used
+        (fd, dbfile) = tempfile.mkstemp(text=True)
+        os.close(fd)
+
+        # This should be ignored
+        os.environ["CHIMEDB_SQLITE"] = dbfile
+
+        db.test_enable()
+
+        db.connect(read_write=True)
+        db.proxy.create_tables([TestTable])
+        TestTable.create(datum=datum_value)
+
+        # Did that work?
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        db.close()
+
+        # The on-disk sqlite database should still be empty
+        stat = os.stat(dbfile)
+        self.assertEqual(stat.st_size, 0)
+        os.remove(dbfile)
+
+    def test_chimedbrc(self):
+        # Create an empty on-disk sqlite database that won't be used
+        (fd, dbfile) = tempfile.mkstemp(text=True)
+        os.close(fd)
+
+        # Create a rcfile
+        (fd, rcfile) = tempfile.mkstemp(text=True)
+        with os.fdopen(fd, "a") as rc:
+            rc.write(
+                """\
+chimedb:
+    db_type: sqlite
+    db: {0}
+""".format(
+                    dbfile
+                )
+            )
+
+        # This should be ignored
+        os.environ["CHIMEDBRC"] = rcfile
+
+        db.test_enable()
+
+        db.connect(read_write=True)
+        db.proxy.create_tables([TestTable])
+        TestTable.create(datum=datum_value)
+
+        # Did that work?
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        db.close()
+
+        # The on-disk sqlite database should still be empty
+        stat = os.stat(dbfile)
+        self.assertEqual(stat.st_size, 0)
+
+        os.unlink(rcfile)
+        os.unlink(dbfile)
+
+    def test_chimedb_test_rc(self):
+        # Create an empty on-disk sqlite database
+        (fd, dbfile) = tempfile.mkstemp(text=True)
+        os.close(fd)
+
+        # Create a rcfile
+        (fd, rcfile) = tempfile.mkstemp(text=True)
+        with os.fdopen(fd, "a") as rc:
+            rc.write(
+                """\
+chimedb:
+    db_type: sqlite
+    db: {0}
+""".format(
+                    dbfile
+                )
+            )
+
+        # This should be ignored
+        os.environ["CHIMEDB_TEST_RC"] = rcfile
+
+        db.test_enable()
+
+        db.connect(read_write=True)
+        db.proxy.create_tables([TestTable])
+        TestTable.create(datum=datum_value)
+
+        # Did that work?
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        db.close()
+
+        # The on-disk sqlite database should not be empty
+        stat = os.stat(dbfile)
+        self.assertNotEqual(stat.st_size, 0)
+
+        os.unlink(rcfile)
+        os.unlink(dbfile)
+
+    def test_no_chimedbrc(self):
+        # This is not allowed
+        os.environ["CHIMEDB_TEST_RC"] = 'any string containing "chimedbrc"'
+
+        db.test_enable()
+
+        with self.assertRaises(OSError):
+            db.connect()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a function, `chimedb.core.test_enable()` which turns on "test-safe mode" which should prevent running unit tests against the production database.