### PR TITLE
feat(core): add atomic decorator/context manager

### DIFF
--- a/chimedb/core/__init__.py
+++ b/chimedb/core/__init__.py
@@ -37,6 +37,17 @@ Exceptions related to database operations (queries and updates):
 * `ValidationError(CHIMEdbError)`
     A cell value failed validation.
 
+Decorators
+==========
+
+You can use the following function decorator for transaction management:
+
+* @atomic
+    Execute the decorated function within a peewee atomic() context.
+
+It will ensure a connection is made to the database and execute the
+decorated function in an atomic context.  The database is not closed.
+
 
 Functions
 =========
@@ -98,5 +109,6 @@ from .exceptions import (
 from .orm import connect_database as connect
 from .orm import database_proxy as proxy
 from .connectdb import close, test_enable
+from .context import atomic
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -153,7 +153,6 @@ import os
 import logging
 import MySQLdb
 import peewee as pw
-from playhouse import shortcuts
 import socket
 import sqlite3
 import yaml

--- a/chimedb/core/context.py
+++ b/chimedb/core/context.py
@@ -1,0 +1,93 @@
+"""CHIMEdb context management."""
+
+import logging
+import functools
+import peewee as pw
+from . import connect, proxy
+
+# Set module logger.
+_logger = logging.getLogger("chimedb")
+
+
+def atomic(_func=None, *, read_write=False):
+    """peewee atomic function decorator
+
+    Use this to decorate a function:
+
+        @chimedb.core.atomic(read_write=True)
+        def func():
+            pass
+
+    Then calling:
+
+        func()
+
+    is equivalent to:
+
+        chimedb.core.connect(read_write=True)
+        with chimedb.core.proxy.atomic():
+            func()
+
+    which ensures all database operations in func() occur in a transaction.
+
+    If func() raises an exception, any pending transaction will be rolled back.
+    Otherwise any pending transaction will be automatically committed when
+    func() exits.
+
+    While within peewee's atomic() context, a transaction is always in progress.
+    As a result, calling chimedb.core.close() from within func() is not allowed.
+
+    This decorator can be used to wrap the invocation of a click group or command
+    (including parameter callbacks).  To do so, place this decorator before the
+    group or command decorator:
+
+        @chimedb.core.atomic(read_write=True)
+        @click.group()
+        @click.option("--opt", type=CHIMEDB_ORM_TYPE)
+        def group_name(opt):
+            pass
+
+    Parameters
+    ----------
+    `read_write` : bool
+        If True, use a read-write connection to the database, otherwise
+        a read-only connection will be established.
+    """
+
+    def atomic_decorator(_func):
+        # If this is a click group or command, shoe-horn ourselves into it by
+        # monkey patching the main() method.
+        _command = None
+        try:
+            import click
+
+            if isinstance(_func, click.Command):
+                _command = _func
+
+                if getattr(_command, "__chimedb_diverted_main__", None):
+                    # already monkey patched.  This decorator has nothing to do.
+                    return _command
+
+                _func = _command.main
+                _command.__chimedb_diverted_main__ = _func
+        except ImportError:
+            pass
+
+        def atomic_wrapper(*args, **kwargs):
+            connect(read_write=read_write)
+
+            _logger.debug("Entering atomic context")
+            with proxy.atomic():
+                ret = _func(*args, **kwargs)
+            _logger.debug("Exited atomic context")
+            return ret
+
+        if _command:
+            _command.main = functools.update_wrapper(atomic_wrapper, _func)
+            return _command
+
+        return functools.update_wrapper(atomic_wrapper, _func)
+
+    if _func is None:
+        return atomic_decorator
+    return atomic_decorator(_func)

--- a/chimedb/core/context.py
+++ b/chimedb/core/context.py
@@ -1,4 +1,9 @@
 """CHIMEdb context management."""
+# === Start Python 2/3 compatibility
+from __future__ import absolute_import, division, print_function, unicode_literals
+from future.builtins import *  # noqa  pylint: disable=W0401, W0614
+from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+# === End Python 2/3 compatibility
 
 import logging
 import functools
@@ -8,8 +13,7 @@ from . import connect, proxy
 # Set module logger.
 _logger = logging.getLogger("chimedb")
 
-
-def atomic(_func=None, *, read_write=False):
+def atomic(_func=None, **_kwargs):
     """peewee atomic function decorator
 
     Use this to decorate a function:
@@ -53,6 +57,12 @@ def atomic(_func=None, *, read_write=False):
         If True, use a read-write connection to the database, otherwise
         a read-only connection will be established.
     """
+
+    # Work-around for "def atomic(_func=None, *, read_write=False):" not working in Py2
+    if 'read_write' in _kwargs:
+        read_write = _kwargs['read_write']
+    else:
+        read_write = False
 
     def atomic_decorator(_func):
         # If this is a click group or command, shoe-horn ourselves into it by

--- a/chimedb/core/context.py
+++ b/chimedb/core/context.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from future.builtins import *  # noqa  pylint: disable=W0401, W0614
 from future.builtins.disabled import *  # noqa  pylint: disable=W0401, W0614
+
 # === End Python 2/3 compatibility
 
 import logging
@@ -12,6 +13,7 @@ from . import connect, proxy
 
 # Set module logger.
 _logger = logging.getLogger("chimedb")
+
 
 def atomic(_func=None, **_kwargs):
     """peewee atomic function decorator
@@ -59,8 +61,8 @@ def atomic(_func=None, **_kwargs):
     """
 
     # Work-around for "def atomic(_func=None, *, read_write=False):" not working in Py2
-    if 'read_write' in _kwargs:
-        read_write = _kwargs['read_write']
+    if "read_write" in _kwargs:
+        read_write = _kwargs["read_write"]
     else:
         read_write = False
 

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -1,0 +1,105 @@
+import os
+import sqlite3
+import logging
+import tempfile
+import unittest
+import peewee as pw
+import chimedb.core as db
+from chimedb.core.orm import base_model
+
+
+class TestTable(base_model):
+    datum = pw.IntegerField()
+
+
+datum_value = 83
+
+
+class TestDecorator(unittest.TestCase):
+    """Test chimedb.core.session"""
+
+    def tearDown(self):
+        import chimedb.core as db
+
+        db.close()
+        os.remove(self.dbfile)
+
+    def setUp(self):
+        # Create a temporary file
+        (fd, self.dbfile) = tempfile.mkstemp()
+        os.close(fd)
+
+        conn = sqlite3.connect(self.dbfile)
+        curs = conn.cursor()
+
+        curs.execute("CREATE TABLE testtable (datum INTEGER)")
+        curs.execute("INSERT INTO testtable VALUES (?)", (datum_value,))
+
+        conn.commit()
+        conn.close()
+
+        os.environ["CHIMEDB_TEST_SQLITE"] = self.dbfile
+        os.environ["CHIMEDB_TEST_ENABLE"] = "1"
+
+    def test_atomic_rollback(self):
+        @db.atomic(read_write=True)
+        def inside_atomic():
+            TestTable.update(datum=datum_value + 1).execute()
+
+            db.proxy.rollback()
+
+        # Execute
+        inside_atomic()
+
+        # Check
+        db.close()
+        db.connect()
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+
+    def test_atomic_commit(self):
+        @db.atomic(read_write=True)
+        def inside_atomic():
+            TestTable.update(datum=datum_value + 1).execute()
+
+            db.proxy.commit()
+
+        # Execute
+        inside_atomic()
+
+        # Check
+        db.close()
+        db.connect()
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value + 1)
+
+    def test_atomic_raise(self):
+        @db.atomic(read_write=True)
+        def inside_atomic():
+            TestTable.update(datum=datum_value + 1).execute()
+
+            raise RuntimeError
+
+        # Execute
+        with self.assertRaises(RuntimeError):
+            inside_atomic()
+
+        # Check
+        db.close()
+        db.connect()
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+
+    def test_atomic_autocommit(self):
+        @db.atomic(read_write=True)
+        def inside_atomic():
+            TestTable.update(datum=datum_value + 1).execute()
+
+        # Execute
+        inside_atomic()
+
+        # Check
+        db.close()
+        db.connect()
+        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -1,10 +1,10 @@
 import os
 import sqlite3
-import logging
 import tempfile
 import unittest
 import peewee as pw
 import chimedb.core as db
+from unittest.mock import patch
 from chimedb.core.orm import base_model
 
 
@@ -19,10 +19,10 @@ class TestDecorator(unittest.TestCase):
     """Test chimedb.core.session"""
 
     def tearDown(self):
-        import chimedb.core as db
-
         db.close()
         os.remove(self.dbfile)
+
+        self.patched_env.stop()
 
     def setUp(self):
         # Create a temporary file
@@ -38,8 +38,10 @@ class TestDecorator(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        os.environ["CHIMEDB_TEST_SQLITE"] = self.dbfile
-        os.environ["CHIMEDB_TEST_ENABLE"] = "1"
+        self.patched_env = patch.dict(
+            os.environ, {"CHIMEDB_TEST_SQLITE": self.dbfile, "CHIMEDB_TEST_ENABLE": "1"}
+        )
+        self.patched_env.start()
 
     def test_atomic_rollback(self):
         @db.atomic(read_write=True)

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -65,7 +65,7 @@ class TestSqlite(unittest.TestCase):
         TestTable.update(datum=datum_value * 2).execute()
         self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value * 2)
 
-    def test_switch_connetion(self):
+    def test_switch_connection(self):
         import chimedb.core as db
 
         self.test_connect_ro()
@@ -92,7 +92,7 @@ chimedb:
 
         # We run this test to make sure BaseConnector.from_dict has made both
         # connectors correctly.
-        self.test_switch_connetion()
+        self.test_switch_connection()
         os.unlink(rcfile)
 
 

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -4,6 +4,7 @@ import sqlite3
 import tempfile
 import unittest
 import peewee as pw
+import chimedb.core as db
 from unittest.mock import patch
 from chimedb.core.orm import base_model
 
@@ -19,14 +20,11 @@ class TestSqlite(unittest.TestCase):
     """Rudemintary tests of connectdb using sqlite"""
 
     def tearDown(self):
-        import chimedb.core as db
-
         self.patched_env.stop()
         db.close()
         os.remove(self.dbfile)
 
     def setUp(self):
-        logging.basicConfig(level=logging.DEBUG)
         # Create a temporary file
         (fd, self.dbfile) = tempfile.mkstemp()
         os.close(fd)
@@ -40,45 +38,31 @@ class TestSqlite(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        self.patched_env = patch.dict(os.environ, {"CHIMEDB_SQLITE": self.dbfile})
+        self.patched_env = patch.dict(os.environ, {"CHIMEDB_TEST_SQLITE": self.dbfile, "CHIMEDB_TEST_ENABLE": "1"})
         self.patched_env.start()
 
-        if "CHIMEDB_TEST_ENABLE" in os.environ:
-            del os.environ["CHIMEDB_TEST_ENABLE"]
-        if "CHIMEDBRC" in os.environ:
-            del os.environ["CHIMEDBRC"]
-        if "CHIMEDB_TEST_SQLITE" in os.environ:
-            del os.environ["CHIMEDB_TEST_SQLITE"]
         if "CHIMEDB_TEST_RC" in os.environ:
             del os.environ["CHIMEDB_TEST_RC"]
 
     def test_connect(self):
-        import chimedb.core as db
-
         db.connect()
         self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
 
     def test_connect_uri(self):
-        os.environ["CHIMEDB_SQLITE"] = "file:" + self.dbfile
+        os.environ["CHIMEDB_TEST_SQLITE"] = "file:" + self.dbfile
         self.test_connect()
 
     def test_connect_ro(self):
-        import chimedb.core as db
-
         db.connect()
         with self.assertRaises(pw.OperationalError):
             TestTable.update(datum=datum_value * 2).execute()
 
     def test_connect_rw(self):
-        import chimedb.core as db
-
         db.connect(read_write=True)
         TestTable.update(datum=datum_value * 2).execute()
         self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value * 2)
 
     def test_switch_connection(self):
-        import chimedb.core as db
-
         self.test_connect_ro()
         self.test_connect_rw()
         self.test_connect_ro()
@@ -98,8 +82,8 @@ chimedb:
                 )
             )
 
-        del os.environ["CHIMEDB_SQLITE"]
-        os.environ["CHIMEDBRC"] = rcfile
+        del os.environ["CHIMEDB_TEST_SQLITE"]
+        os.environ["CHIMEDB_TEST_RC"] = rcfile
 
         # We run this test to make sure BaseConnector.from_dict has made both
         # connectors correctly.

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -38,7 +38,9 @@ class TestSqlite(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        self.patched_env = patch.dict(os.environ, {"CHIMEDB_TEST_SQLITE": self.dbfile, "CHIMEDB_TEST_ENABLE": "1"})
+        self.patched_env = patch.dict(
+            os.environ, {"CHIMEDB_TEST_SQLITE": self.dbfile, "CHIMEDB_TEST_ENABLE": "1"}
+        )
         self.patched_env.start()
 
         if "CHIMEDB_TEST_RC" in os.environ:

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -41,6 +41,15 @@ class TestSqlite(unittest.TestCase):
         self.patched_env = patch.dict(os.environ, {"CHIMEDB_SQLITE": self.dbfile})
         self.patched_env.start()
 
+        if "CHIMEDB_TEST_ENABLE" in os.environ:
+            del os.environ["CHIMEDB_TEST_ENABLE"]
+        if "CHIMEDBRC" in os.environ:
+            del os.environ["CHIMEDBRC"]
+        if "CHIMEDB_TEST_SQLITE" in os.environ:
+            del os.environ["CHIMEDB_TEST_SQLITE"]
+        if "CHIMEDB_TEST_RC" in os.environ:
+            del os.environ["CHIMEDB_TEST_RC"]
+
     def test_connect(self):
         import chimedb.core as db
 

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import sqlite3
 import tempfile
 import unittest
@@ -25,6 +26,7 @@ class TestSqlite(unittest.TestCase):
         os.remove(self.dbfile)
 
     def setUp(self):
+        logging.basicConfig(level=logging.DEBUG)
         # Create a temporary file
         (fd, self.dbfile) = tempfile.mkstemp()
         os.close(fd)


### PR DESCRIPTION
Because I hate me some race conditions, after realising that `cdf` (and hence the node hardware tracker I'm writing) could run in to trouble by independently accessing the database first in a parameter callback and then, separately, in a command callback, I figured someone should fix it.

So here we go: this adds a decorator (`@atomic`) we can use to transactionify a click command:

```(Python)
import click
import chimedb.core as db

@db.atomic(read_write=True)
@click.group
@click.option("--opt", type=SOMETHING_INVOLVING_CHIMEDB_ACCESS)
def whatever(opt):
    more_chimedb_access_here()
```

The database connection happens automatically.  The transaction will automatically be committed when the command finishes, unless it raises an exception, which will cause the whole thing to be rolled back (per standard peewee`atomic` context behaviour).

It also works when decorating "regular" functions.