### PR TITLE
fix(connectdb): Re-use existing DB connection

### DIFF
--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -449,7 +449,7 @@ class MySQLConnector(BaseConnector):
 
     def get_peewee_database(self):
         self.ensure_route_to_database()
-        if self._database is None:
+        if self._database is None or not self._database.is_connection_usable():
             host, port = self._host_port()
             try:
                 self._database = MySQLDatabaseReconnect(

--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -578,7 +578,7 @@ class SqliteConnector(BaseConnector):
         return connection
 
     def get_peewee_database(self):
-        if self._database is None:
+        if self._database is None or not self._database.is_connection_usable():
             self._database = pw.SqliteDatabase(
                 self._db, uri=True if self._db.startswith("file:") else False
             )

--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -448,7 +448,10 @@ class MySQLConnector(BaseConnector):
         return connection
 
     def get_peewee_database(self):
+        # This will set self._database to None if a new tunnel is established
+        # (possibly because the old one died)
         self.ensure_route_to_database()
+
         if self._database is None or not self._database.is_connection_usable():
             host, port = self._host_port()
             try:


### PR DESCRIPTION
This avoids instantiating a new peewee `Database` (and, hence, creating a new database connection) in the `get_peewee_database` calls if one already exists.  I suspect this is what we intended to happen all along.

Without this fix, every call to `chimedb.core.connect()` results in a new connection to the database being established.  In theory, for normal connections to the MySQL database, this is not a problem: one connection should be the same as any other.  (The previous connection is closed during GC).

However, this can cause trouble when using an in-memory SQLite database in test-safe mode.

I also wonder if this is the cause of some of the unexplained DB connection loss we've experienced, especially in `alpenhornd`, but I have no real evidence for that.