### PR TITLE
build: Bump peewee version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "mysqlclient",
-        "peewee >= 3.10",
+        "peewee >= 3.12",
         "sshtunnel",
         "ujson",
         "future",


### PR DESCRIPTION
Apparently `is_connection_usable` was added in Peewee 3.12.