### PR TITLE
fix: restrict the version of mysql-connector to one that works with MariaDB

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        "mysql-connector-python",
+        "mysql-connector-python >= 8.0, <= 8.0.29",
         "peewee >= 3.12",
         "sshtunnel >= 0.4.0",
         "ujson",


### PR DESCRIPTION
Newer versions of mysql-connector seem to have an issue with the charset settings that old versions of MariaDB use, this restricts the version to ones that I know work.