### PR TITLE
fix: ignore ssh config

### DIFF
--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -502,6 +502,7 @@ class MySQLConnector(BaseConnector):
         try:
             self._tunnel = sshtunnel.SSHTunnelForwarder(
                 self._tunnel_host,
+                ssh_config_file=None,
                 remote_bind_address=(self._host, self._port),
                 local_bind_address=(_LOCALHOST,),
                 ssh_username=self._tunnel_user,


### PR DESCRIPTION
Paramiko's parsing of ssh config is a little broken and doesn't like
complex Match constructs. This ignores the ssh_config as our setup is
quite straightforward.

It breaks spectacularly on my ssh config (trying to tunnel through tubular!!).
I don't imagine most people have complex ssh configs and so this turns it off.
You can always override the config with a `.chimedbrc` file.

Thoughts @ketiltrout ?
