### PR TITLE
Alpenhorn-2 integration

### DIFF
--- a/chimedb/core/alpenhorn.py
+++ b/chimedb/core/alpenhorn.py
@@ -1,0 +1,32 @@
+"""Alpenhorn-2 integration.
+
+Provides an extension module for alpenhorn-2.
+"""
+
+import peewee as pw
+
+from . import connectdb
+from .exceptions import ConnectionError, NoRouteToDatabase
+
+
+def connect(config):
+    """connectdb.connect() boilperplate"""
+    try:
+        connectdb.connect()
+    except (NoRouteToDatabase, ConnectionError) as e:
+        raise pw.OperationalError("chimedb connection failed") from e
+
+    # Retrieve the database connection
+    connector = connectdb.current_connector(read_write=True)
+
+    if not connector:
+        raise pw.OperationalError("No database connection could be established.")
+
+    return connector.get_peewee_database()
+
+
+def register_extension():
+    """Register an alpenhorn database extension."""
+    return {
+        "database": {"connect": connect, "close": connectdb.close, "reentrant": True}
+    }

--- a/chimedb/core/alpenhorn.py
+++ b/chimedb/core/alpenhorn.py
@@ -1,6 +1,11 @@
 """Alpenhorn-2 integration.
 
-Provides an extension module for alpenhorn-2.
+Provides a database extension module for alpenhorn-2 which
+connects chimedb and alpenhorn, allowing alpenhorn to use this
+package for database access.
+
+See `alpenhorn.extensions` and `alpenhorn.db` for more details
+on what an alpenhorn database extension is.
 """
 
 import peewee as pw
@@ -10,7 +15,26 @@ from .exceptions import ConnectionError, NoRouteToDatabase
 
 
 def connect(config):
-    """connectdb.connect() boilperplate"""
+    """Connect to the CHIMEDB for alpenhorn use.
+
+    This is a wrapper around `connectdb.connect` which will be called by
+    `alpenhorn` to establish a database connection.
+
+    The `peewee.Database` from the read-write connector is returned
+    to alpenhorn.
+
+    Parameters
+    ----------
+    config : dict
+        Ignored.  This is the parsed contents of the "database" section of the
+        alpenhorn config file.  This function ignores this configuration
+        data: set up CHIMEDB in the usual way to use it with alpenhorn.
+
+    Raises
+    ------
+    peewee.OperationalError
+        On database connection failure
+    """
     try:
         connectdb.connect()
     except (NoRouteToDatabase, ConnectionError) as e:
@@ -26,7 +50,11 @@ def connect(config):
 
 
 def register_extension():
-    """Register an alpenhorn database extension."""
+    """Register an alpenhorn database extension.
+
+    Returns a "capability dict" providing the database capabilities of this
+    database module to alpenhorn.
+    """
     return {
         "database": {"connect": connect, "close": connectdb.close, "reentrant": True}
     }

--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -561,7 +561,8 @@ class SqliteConnector(BaseConnector):
     def get_connection(self):
         try:
             connection = sqlite3.connect(
-                self._db, uri=True if self._db.startswith("file:") else False
+                self._db,
+                uri=True if self._db.startswith("file:") else False,
             )
         except sqlite3.OperationalError:
             raise ConnectionError(
@@ -572,7 +573,8 @@ class SqliteConnector(BaseConnector):
     def get_peewee_database(self):
         if self._database is None or not self._database.is_connection_usable():
             self._database = pw.SqliteDatabase(
-                self._db, uri=True if self._db.startswith("file:") else False
+                self._db,
+                uri=True if self._db.startswith("file:") else False,
             )
         return self._database
 

--- a/chimedb/core/orm.py
+++ b/chimedb/core/orm.py
@@ -89,13 +89,16 @@ class EnumField(pw.Field):
         else:
             return [self.maxlen]
 
-    def coerce(self, val):
-        # Coerce the db/python value to the correct output. Also perform
-        # validation for non native ENUMs.
-        if self.native or val in self.enum_list:
-            return str(val or "")
+    def db_value(self, val):
+        """Verify supplied value before handing off to DB."""
+
+        # If we're using a native Enum field, just let the DBMS decide what to do
+        # Otherwise, allow values in the enum_list and the null value (which may
+        # be rejected by the database, but that's not our problem.)
+        if self.native or val in self.enum_list or val is None:
+            return val
         else:
-            raise TypeError("Value %s not in ENUM(%s)" % str(self.value))
+            raise ValueError(f'invalid value "{val}" for EnumField')
 
 
 class JSONDictField(pw.TextField):

--- a/chimedb/core/orm.py
+++ b/chimedb/core/orm.py
@@ -400,7 +400,6 @@ def create_tables(packages=None, ignore=list(), check=False):
     # Construct the list of tables
     def find_tables(model, tables, ignore):
         for cls in model.__subclasses__():
-
             if cls.__name__ in ignore:
                 continue
             tables.append(cls)


### PR DESCRIPTION
This PR adds an alpenhorn2-style database extension module called `chimedb.core.alpenhorn`.

## Alpenhorn database extension

An alpenhorn-2 extension needs to provide a `register_extension()` function.  In the case of a database extension, like this one, the `register_extension` function returns a dictionary containing a `"database"` key whose value is a sub-dictionary describing the capabilities of the registered extension.

In particular, the CHIMEDB database extension provides access to the standard CHIMEDB `connect` and `close` methods for managing database connections.  All connections provided to alpenhorn have `read_write=True`.

This PR is tied to https://github.com/radiocosmology/alpenhorn/pull/144, which modifies alpenhorn to support the type of `register_extension` we provide.

## Fixes for peewee-3

This PR also fixes `EnumField` and `RetryOperationalError`, which I don't think have ever really worked properly in peewee-3.

### EnumField
The `EnumField` used to use a method called `coerce`, which might have been used in Peewee-2, but isn't ever called in peewee-3.  The replacement in peewee-3 seems to be `db_value`.   This is only a problem for non-native `EnumField`s, which means when using this code with the MySQL production database, there is no problem.

### RetryOperationalError
I haven't actually checked, but I think the `RetryOperationalError` mixin which we copied from the peewee issue was designed for peewee-2.  The former code made the following assumptions in order to function properly:
  * A transaction is not in-progress
  * The value for the `commit` parameter was explicitly set to `True` or `False`.
  * The database has been opened with `autoconnect=True`
  * The database has been opened with `autorollback=False`
 
Of these assumptions, the first is probably the most likely to be wrong.  The `commit` default has changed in peewee-3 to a special `SENTINEL` value which is interpreted by peewee as either False or True, depending on the type of statement being executed.  I don't think we ever modify the properties in the last two assumptions (which are both defaults), so they're probably fine.

My change fixes the first and third assumptions by simply continuing to crash if they're false.  In both cases, the mixin won't be able to run properly, so it's probably best just to let the caller figure out how to recover in this situation.  The second and fourth assumptions are fixed by eplicitly re-calling `super().execute_sql` which sort out what to do with both of these, rather than manually trying to execute the SQL.  (I think the `pw.__exception_wrapper__` block that I deleted was the guts of the `execute_sql` implementation from peewee-2).

These two fixes have also been ported to the alpenhorn rewrite: https://github.com/radiocosmology/alpenhorn/pull/144