### PR TITLE
fix(mediawiki): Fix field type of MediaWikiUser.user_name

### DIFF
--- a/chimedb/core/mediawiki.py
+++ b/chimedb/core/mediawiki.py
@@ -32,7 +32,7 @@ class MediaWikiUser(base_model):
     """
 
     user_id = pw.IntegerField(primary_key=True)
-    user_name = pw.TextField()
+    user_name = pw.BlobField()
     user_password = pw.TextField()
 
     @classmethod


### PR DESCRIPTION
The field in the database is a VARBINARY.  Using pewee's `TextField` on that returns values as `"bytearray(b'Name')"` (i.e. as a Python `str` containing the `repr` of the `binary` field data, which is just wild).

Changing the field type to `BlobField` results in `MediaWikiUser.user_name` being a `binary`-encoded string, as expected.

Closes #31 