### PR TITLE
build: Add pymysql dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     install_requires=[
         "mysql-connector-python >= 8.0, <= 8.0.29",
         "peewee >= 3.12",
+        "pymysql",
         "sshtunnel >= 0.4.0",
         "ujson",
         "future",


### PR DESCRIPTION
This fixes a regression from PR #27 which replaced the `MySQLdb` requirement with `mysql.connector`.  This substitution effectively removed support for MySQL from `peewee` in new installs, because `peewee` was using `MySQLdb` for MySQL database access, but it doesn't have `MySQLdb` as a dependency (because it doesn't want to force MySQL on you if you don't want it).

To fix this, I've added a requirement for `pymsql`, a pure-python replacement for `MySQLdb` which `peewee` supports as an alternative.