### PR TITLE
fix(connectdb): Upgrade to peewee-3.16.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "mysql-connector-python >= 8.0, <= 8.0.29",
-        "peewee >= 3.12",
-        "pymysql",
+        "peewee >= 3.16.3",
         "sshtunnel >= 0.4.0",
         "ujson",
         "future",


### PR DESCRIPTION
Three things:

1. Upgrade the minimum peewee version to 3.16.3 to avoid needing `pymsql`.  Closes #39 

2. Be less draconian about filtering passwords from the log.  Now only the actual password message is filtered, and the filter can be stopped by calling connectdb.secure_logging(False).

3. Fix the deprecation warning in execute_sql() for peewee >= 3.16, which outputs a DeprecationWarning in execute_sql if `commit` (which is now unused) is not None.