### PR TITLE
ci: Add ruff check and update workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
 
-  lint-code:
+  black-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: "3.9"
 
     - name: Install black
       run: pip install black
@@ -26,15 +26,37 @@ jobs:
       run: |
         black --check .
 
-  run-tests:
+  ruff-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: "3.9"
+
+    - name: Install chimedb.core
+      run: pip install .
+
+    - name: Install ruff
+      run: pip install ruff
+
+    - name: Check code with ruff
+      run: ruff check .
+
+  run-tests:
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install chimedb
       run: |

--- a/chimedb/core/__init__.py
+++ b/chimedb/core/__init__.py
@@ -122,3 +122,21 @@ from . import mediawiki
 from . import _version
 
 __version__ = _version.get_versions()["version"]
+del _version
+
+__all__ = [
+    "CHIMEdbError",
+    "NotFoundError",
+    "ValidationError",
+    "InconsistencyError",
+    "AlreadyExistsError",
+    "NoRouteToDatabase",
+    "ConnectionError",
+    "connect",
+    "proxy",
+    "close",
+    "test_enable",
+    "atomic",
+    "mediawiki",
+    "__version__",
+]

--- a/chimedb/core/context.py
+++ b/chimedb/core/context.py
@@ -2,7 +2,6 @@
 
 import logging
 import functools
-import peewee as pw
 from . import connect, proxy
 
 # Set module logger.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "future",
         "PyYAML",
     ],
+    python_requires=">=3.9",
     author="The CHIME Collaboration",
     author_email="dvw@phas.ubc.ca",
     description="Low-level CHIME database access",

--- a/test/test_current_connector.py
+++ b/test/test_current_connector.py
@@ -14,7 +14,3 @@ class TestCurrentConnector(unittest.TestCase):
 
     def test_uninitialised_rw(self):
         self.assertEqual(connectdb.current_connector(read_write=True), None)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from chimedb.core.orm import base_model
 
 
-class TestTable(base_model):
+class TableTest(base_model):
     datum = pw.IntegerField()
 
 
@@ -32,8 +32,8 @@ class TestDecorator(unittest.TestCase):
         conn = sqlite3.connect(self.dbfile)
         curs = conn.cursor()
 
-        curs.execute("CREATE TABLE testtable (datum INTEGER)")
-        curs.execute("INSERT INTO testtable VALUES (?)", (datum_value,))
+        curs.execute("CREATE TABLE tabletest (datum INTEGER)")
+        curs.execute("INSERT INTO tabletest VALUES (?)", (datum_value,))
 
         conn.commit()
         conn.close()
@@ -46,7 +46,7 @@ class TestDecorator(unittest.TestCase):
     def test_atomic_rollback(self):
         @db.atomic(read_write=True)
         def inside_atomic():
-            TestTable.update(datum=datum_value + 1).execute()
+            TableTest.update(datum=datum_value + 1).execute()
 
             db.proxy.rollback()
 
@@ -56,12 +56,12 @@ class TestDecorator(unittest.TestCase):
         # Check
         db.close()
         db.connect()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
 
     def test_atomic_commit(self):
         @db.atomic(read_write=True)
         def inside_atomic():
-            TestTable.update(datum=datum_value + 1).execute()
+            TableTest.update(datum=datum_value + 1).execute()
 
             db.proxy.commit()
 
@@ -71,12 +71,12 @@ class TestDecorator(unittest.TestCase):
         # Check
         db.close()
         db.connect()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value + 1)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value + 1)
 
     def test_atomic_raise(self):
         @db.atomic(read_write=True)
         def inside_atomic():
-            TestTable.update(datum=datum_value + 1).execute()
+            TableTest.update(datum=datum_value + 1).execute()
 
             raise RuntimeError
 
@@ -87,12 +87,12 @@ class TestDecorator(unittest.TestCase):
         # Check
         db.close()
         db.connect()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
 
     def test_atomic_autocommit(self):
         @db.atomic(read_write=True)
         def inside_atomic():
-            TestTable.update(datum=datum_value + 1).execute()
+            TableTest.update(datum=datum_value + 1).execute()
 
         # Execute
         inside_atomic()
@@ -100,8 +100,4 @@ class TestDecorator(unittest.TestCase):
         # Check
         db.close()
         db.connect()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value + 1)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value + 1)

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from chimedb.core.orm import base_model
 
 
-class TestTable(base_model):
+class TableTest(base_model):
     datum = pw.IntegerField()
 
 
@@ -31,8 +31,8 @@ class TestSqlite(unittest.TestCase):
         conn = sqlite3.connect(self.dbfile)
         curs = conn.cursor()
 
-        curs.execute("CREATE TABLE testtable (datum INTEGER)")
-        curs.execute("INSERT INTO testtable VALUES (?)", (datum_value,))
+        curs.execute("CREATE TABLE tabletest (datum INTEGER)")
+        curs.execute("INSERT INTO tabletest VALUES (?)", (datum_value,))
 
         conn.commit()
         conn.close()
@@ -47,7 +47,7 @@ class TestSqlite(unittest.TestCase):
 
     def test_connect(self):
         db.connect()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
 
     def test_connect_uri(self):
         os.environ["CHIMEDB_TEST_SQLITE"] = "file:" + self.dbfile
@@ -56,18 +56,18 @@ class TestSqlite(unittest.TestCase):
     def test_connect_ro(self):
         db.connect()
         with self.assertRaises(pw.OperationalError):
-            TestTable.update(datum=datum_value * 2).execute()
+            TableTest.update(datum=datum_value * 2).execute()
 
     def test_connect_rw(self):
         db.connect(read_write=True)
-        TestTable.update(datum=datum_value * 2).execute()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value * 2)
+        TableTest.update(datum=datum_value * 2).execute()
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value * 2)
 
     def test_switch_connection(self):
         self.test_connect_ro()
         self.test_connect_rw()
         self.test_connect_ro()
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value * 2)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value * 2)
 
     def test_rcfile(self):
         # Create a temporary file
@@ -90,7 +90,3 @@ chimedb:
         # connectors correctly.
         self.test_switch_connection()
         os.unlink(rcfile)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_test_enable.py
+++ b/test/test_test_enable.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from chimedb.core.orm import base_model
 
 
-class TestTable(base_model):
+class TableTest(base_model):
     datum = pw.IntegerField()
 
 
@@ -45,11 +45,11 @@ class TestSafeMode(unittest.TestCase):
         db.test_enable()
 
         db.connect(read_write=True)
-        db.proxy.create_tables([TestTable])
-        TestTable.create(datum=datum_value)
+        db.proxy.create_tables([TableTest])
+        TableTest.create(datum=datum_value)
 
         # Did that work?
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
         db.close()
 
         # The on-disk sqlite database should not be empty anymore
@@ -66,11 +66,11 @@ class TestSafeMode(unittest.TestCase):
         os.environ["CHIMEDB_TEST_ENABLE"] = "1"
 
         db.connect(read_write=True)
-        db.proxy.create_tables([TestTable])
-        TestTable.create(datum=datum_value)
+        db.proxy.create_tables([TableTest])
+        TableTest.create(datum=datum_value)
 
         # Did that work?
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
         db.close()
 
         # The on-disk sqlite database should not be empty anymore
@@ -88,11 +88,11 @@ class TestSafeMode(unittest.TestCase):
         db.test_enable()
 
         db.connect(read_write=True)
-        db.proxy.create_tables([TestTable])
-        TestTable.create(datum=datum_value)
+        db.proxy.create_tables([TableTest])
+        TableTest.create(datum=datum_value)
 
         # Did that work?
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
         db.close()
 
         # The on-disk sqlite database should still be empty
@@ -124,11 +124,11 @@ chimedb:
         db.test_enable()
 
         db.connect(read_write=True)
-        db.proxy.create_tables([TestTable])
-        TestTable.create(datum=datum_value)
+        db.proxy.create_tables([TableTest])
+        TableTest.create(datum=datum_value)
 
         # Did that work?
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
         db.close()
 
         # The on-disk sqlite database should still be empty
@@ -162,11 +162,11 @@ chimedb:
         db.test_enable()
 
         db.connect(read_write=True)
-        db.proxy.create_tables([TestTable])
-        TestTable.create(datum=datum_value)
+        db.proxy.create_tables([TableTest])
+        TableTest.create(datum=datum_value)
 
         # Did that work?
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
+        self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
         db.close()
 
         # The on-disk sqlite database should not be empty
@@ -184,7 +184,3 @@ chimedb:
 
         with self.assertRaises(OSError):
             db.connect()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_test_enable.py
+++ b/test/test_test_enable.py
@@ -77,27 +77,6 @@ class TestSafeMode(unittest.TestCase):
         stat = os.stat(dbfile)
         self.assertNotEqual(stat.st_size, 0)
 
-    def test_chimedb_test_sqlite(self):
-        # Create an empty on-disk sqlite database
-        (fd, dbfile) = tempfile.mkstemp(text=True)
-        os.close(fd)
-
-        os.environ["CHIMEDB_TEST_SQLITE"] = dbfile
-
-        db.test_enable()
-
-        db.connect(read_write=True)
-        db.proxy.create_tables([TestTable])
-        TestTable.create(datum=datum_value)
-
-        # Did that work?
-        self.assertEqual(TestTable.select(TestTable.datum).scalar(), datum_value)
-        db.close()
-
-        # The on-disk sqlite database should not be empty anymore
-        stat = os.stat(dbfile)
-        self.assertNotEqual(stat.st_size, 0)
-
     def test_chimedb_sqlite(self):
         # Create an empty on-disk sqlite database that won't be used
         (fd, dbfile) = tempfile.mkstemp(text=True)


### PR DESCRIPTION
* Ruff check
* Minimum python set to 3.9.
* Test on both 3.9 and 3.12
* Renamed the test DB table in the test suite to "TableTest" to avoid confusing pytest.