### PR TITLE
Project name is 'chimedb' not 'chimedb.core'

### DIFF
--- a/chimedb/core/__init__.py
+++ b/chimedb/core/__init__.py
@@ -139,7 +139,7 @@ __all__ = [
 from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = version("chimedb.core")
+    __version__ = version("chimedb")
 except PackageNotFoundError:
     # package is not installed
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "chimedb.core"
+name = "chimedb"
 authors = [
   {name = "The CHIME Collaboration", email = "dvw@phas.ubc.ca"}
 ]


### PR DESCRIPTION
My bad.

This project is supposed to advertise that it is the base `chimedb` package.   Which explains all the `chimedb @ ...` requirements elsewhere.