### PR TITLE
build: Require mysql-connector-python >= 9.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dynamic = ["readme", "version"]
 license = {file = "LICENSE"}
 dependencies = [
-    "mysql-connector-python >= 8.0, <= 8.0.29",
+    "mysql-connector-python >= 9.1.0",
     "peewee >= 3.16.3",
     "sshtunnel >= 0.4.0",
     "ujson",


### PR DESCRIPTION
`mysql-connector-python` before 9.1.0 contain a critical vulnerability: https://github.com/chime-experiment/chimedb/security/dependabot/1

Richard originally pinned the version to <= 8.0.29 in #29 due to a charset mismatch in MariaDB.  This bug was fixed in version 8.0.32, so shouldn't be a problem for us anymore.