### PR TITLE
fix(alpenhorn): Use connect_database for database connection

### DIFF
--- a/chimedb/core/alpenhorn.py
+++ b/chimedb/core/alpenhorn.py
@@ -11,6 +11,7 @@ on what an alpenhorn database extension is.
 import peewee as pw
 
 from . import connectdb
+from .orm import connect_database
 from .exceptions import ConnectionError, NoRouteToDatabase
 
 
@@ -36,9 +37,9 @@ def connect(config):
         On database connection failure
     """
     try:
-        connectdb.connect()
+        connect_database()
     except (NoRouteToDatabase, ConnectionError) as e:
-        raise pw.OperationalError("chimedb connection failed") from e
+        raise pw.OperationalError(f"chimedb connection failed: {e}") from e
 
     # Retrieve the database connection
     connector = connectdb.current_connector(read_write=True)

--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -483,7 +483,7 @@ class MySQLConnector(BaseConnector):
             if self._tunnel is not None and self._tunnel.is_active:
                 self._tunnel.stop(force=True)
             raise ConnectionError(
-                "Operational Error while connecting to database: {0}".format(e)
+                f"Operational Error while connecting to database: {e}"
             ) from e
         return connection
 
@@ -505,7 +505,7 @@ class MySQLConnector(BaseConnector):
                 )
             except None:
                 # TODO More descriptive here.
-                raise ConnectionError("Failed to connect to database.")
+                raise ConnectionError("Failed to connect to database")
         return self._database
 
     @property
@@ -574,7 +574,7 @@ class MySQLConnector(BaseConnector):
         self._tunnel.skip_tunnel_checkup = False
         self._tunnel.check_tunnels()  # This waits for the tunnel to come up
         if not self._tunnel.tunnel_is_up[(_LOCALHOST, self._tunnel_port)]:
-            raise ConnectionError("An error occurred while setting up the tunnel.")
+            raise ConnectionError("An error occurred while setting up the tunnel")
 
     def close(self):
         """Close an open connection."""
@@ -616,9 +616,7 @@ class SqliteConnector(BaseConnector):
                 uri=True if self._db.startswith("file:") else False,
             )
         except sqlite3.OperationalError:
-            raise ConnectionError(
-                "Failed to connect to Sqlite database {0}.".format(self._db)
-            )
+            raise ConnectionError(f"Failed to connect to Sqlite database {self._db}")
         return connection
 
     def get_peewee_database(self):
@@ -822,7 +820,7 @@ def connect(reconnect=False):
                 raise NoRouteToDatabase(
                     "Unable to find connection configuration for the database!"
                     "Either provide a chimedb RC file in one of the default"
-                    "locations or install `chimedb.config`."
+                    "locations or install `chimedb.config`"
                 ) from e
             else:
                 context = "chimedb.config"
@@ -837,7 +835,7 @@ def connect(reconnect=False):
 
     if current_connector is None or current_connector_RW is None:
         raise ConnectionError(
-            "Connection data found, but no connection could be established."
+            "Connection data found, but no connection could be established"
         )
 
 

--- a/chimedb/core/orm.py
+++ b/chimedb/core/orm.py
@@ -116,7 +116,7 @@ class JSONDictField(pw.TextField):
             return None
 
         if not isinstance(value, dict):
-            raise ValueError("Python value must be a dict. Received %s" % type(value))
+            raise ValueError(f"Python value must be a dict. Received {type(value)}")
 
         return ujson.dumps(value)
 
@@ -129,9 +129,7 @@ class JSONDictField(pw.TextField):
         pyval = ujson.loads(value)
 
         if not isinstance(pyval, dict):
-            raise ValueError(
-                "Database value must convert to dict. Got %s" % type(pyval)
-            )
+            raise ValueError(f"Database value must convert to dict. Got {type(pyval)}")
 
         return pyval
 
@@ -327,7 +325,7 @@ def connect_database(read_write=False, reconnect=False, ntries=1):
         except ConnectionError as e:
             if i == ntries - 1:
                 raise ConnectionError(
-                    f"Failed to connect to chimedb after {ntries} attempts."
+                    f"Failed to connect to chimedb after {ntries} attempt{'s' if ntries == 1 else ''}: {e}"
                 ) from e
 
             wait = max(60, 5 * 2**i)
@@ -346,7 +344,7 @@ def connect_database(read_write=False, reconnect=False, ntries=1):
     connector = connectdb.current_connector(read_write)
 
     if not connector:
-        raise ConnectionError("No database connection could be established.")
+        raise ConnectionError("No database connection could be established")
 
     pw_database = connector.get_peewee_database()
 


### PR DESCRIPTION
This ensure all chimedb tables are connected to the database, not just alpenhorn's own.

Also a lot of futzing with error messages to try to propagage CHIMEdb connection problems all the way out to the alpenhorn CLI, when appropriate.