### PR TITLE
refactor(connectdb): Use pymysql instead of mysql.connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ requires-python = ">=3.10"
 dynamic = ["readme", "version"]
 license = {file = "LICENSE"}
 dependencies = [
-    "mysql-connector-python >= 9.1.0,<9.3",
     "peewee >= 3.16.3",
+    "pymysql",
     "sshtunnel >= 0.4.0",
     "ujson",
     "PyYAML"


### PR DESCRIPTION
Originally, `chimedb.core` used the C-extension `MySQLdb` to connect to the database.  Eventually we got fed up with having to compile against the mysql client CAPI library, so we switched to `mysql.connector`, which was a new pure-python alternative provided by Oracle (owners of MySQL).

However, that was all back in the Python2 times.  Now there's `pymysql` which is `peewee`'s preferred way of interfacing with MySQL.  So, let's try that.

This is mostly a drop-in replacement, but it does allow us to do away with both the `mysql.connector` log filtering (which was printing the DB password in plain text at log level DEBUG) and also the `playhouse.mysql_ext` stub providing `MySQLDatabase` support for `mysql.connector` (which is where the 9.3.0 bug we've encountered comes from).

I've done some light testing, and things seem to be working as intended.  NOTE: the thread-local storage stuff probably isn't needed anymore (that was necessary in the `MySQLdb` C-extension days), but I'll save looking in to that for another PR.

This is a response to #49 .