### PR TITLE
Updates for peewee-4

### DIFF
--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -236,7 +236,7 @@ class RetryOperationalError:
         autoreconnect.
         """
         try:
-            cursor = super().execute_sql(sql, params, commit)
+            cursor = super().execute_sql(sql, params)
         except pw.OperationalError:
             # If we're in a transaction or the database isn't
             # set to autoconnect, there's not much we can do,
@@ -250,7 +250,7 @@ class RetryOperationalError:
 
             # And then retry.  This will re-open the DB because
             # we've just closed it and autoconnect is True.
-            cursor = super().execute_sql(sql, params, commit)
+            cursor = super().execute_sql(sql, params)
         return cursor
 
 

--- a/chimedb/core/context.py
+++ b/chimedb/core/context.py
@@ -8,7 +8,7 @@ from . import connect, proxy
 _logger = logging.getLogger("chimedb")
 
 
-def atomic(_func=None, **_kwargs):
+def atomic(_func=None, *, read_write=False, pass_transaction=False):
     """peewee atomic function decorator
 
     Use this to decorate a function:
@@ -48,16 +48,13 @@ def atomic(_func=None, **_kwargs):
 
     Parameters
     ----------
-    `read_write` : bool
+    read_write : bool
         If True, use a read-write connection to the database, otherwise
         a read-only connection will be established.
+    pass_transaction : bool
+        If True, the peewee transaction will be passed to the wrapped function
+        as a keyword argument called "transaction".
     """
-
-    # Work-around for "def atomic(_func=None, *, read_write=False):" not working in Py2
-    if "read_write" in _kwargs:
-        read_write = _kwargs["read_write"]
-    else:
-        read_write = False
 
     def atomic_decorator(_func):
         # If this is a click group or command, shoe-horn ourselves into it by
@@ -85,6 +82,10 @@ def atomic(_func=None, **_kwargs):
 
             _logger.debug("Entering atomic context")
             with proxy.atomic() as transaction:
+                # If we were asked to pass the transaction, add it to the keyword args
+                if pass_transaction:
+                    kwargs["transaction"] = transaction
+
                 try:
                     ret = _func(*args, **kwargs)
                 except SystemExit as e:

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -44,11 +44,11 @@ class TestDecorator(unittest.TestCase):
         self.patched_env.start()
 
     def test_atomic_rollback(self):
-        @db.atomic(read_write=True)
-        def inside_atomic():
+        @db.atomic(read_write=True, pass_transaction=True)
+        def inside_atomic(transaction):
             TableTest.update(datum=datum_value + 1).execute()
 
-            db.proxy.rollback()
+            transaction.rollback()
 
         # Execute
         inside_atomic()
@@ -59,11 +59,11 @@ class TestDecorator(unittest.TestCase):
         self.assertEqual(TableTest.select(TableTest.datum).scalar(), datum_value)
 
     def test_atomic_commit(self):
-        @db.atomic(read_write=True)
-        def inside_atomic():
+        @db.atomic(read_write=True, pass_transaction=True)
+        def inside_atomic(transaction):
             TableTest.update(datum=datum_value + 1).execute()
 
-            db.proxy.commit()
+            transaction.commit()
 
         # Execute
         inside_atomic()


### PR DESCRIPTION
Peewee 4.0.0 released Friday.  There are two fixes:

* Remove the `commit` argument to `execute_sql`.  This is the showstopper: without this fix, no queries work in peewee-4.  The `commit` argument has been deprecated for some time now (cf. #40 ).
* Add an optional `pass_transaction` bool to the `atomic` decorator which can be used in functions that want to manually manipulate the transaction.
* Also: removed the py-2 work-around in the dectorator.

I have run the test suite in peewee-3.19 and peewee-4.0.