### PR TITLE
refactor(connectdb): Use asyncssh for connection tunnelling

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,9 +58,29 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install chimedb
+      # Set up SSH so the tunnel test can ssh to localhost.
+    - name: Install OpenSSH
+      run: sudo apt-get install openssh-server openssh-client
+
+    - name: Create user ssh directory
+      run: mkdir ~/.ssh && chmod -c 0700 ~/.ssh
+
+    - name: Create SSH key
+      run: ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
+
+    - name: Create authorized_keys
       run: |
-        pip install .[test]
+        cp ~/.ssh/id_ed25519.pub ~/.ssh/authorized_keys
+        chmod -c 0600 ~/.ssh/authorized_keys
+
+    - name: Create known_hosts file
+      run: |
+        touch ~/.ssh/known_hosts
+        chmod -c 0600 ~/.ssh/known_hosts
+        ssh 127.0.0.1 -oStrictHostKeyChecking=accept-new /bin/true
+
+    - name: Install chimedb
+      run: pip install .[test]
 
     - name: Run tests
-      run: pytest .
+      run: pytest -sv .

--- a/chimedb/core/connectdb.py
+++ b/chimedb/core/connectdb.py
@@ -57,10 +57,14 @@ Or for a sqlite database:
         db_type:         sqlite
         db:              <filename or URI>
 
-(Of course, you should put proper arguments in your file! No quotation marks
-should be used for strings.) If no tunnel is required, simply omit the
-``tunnel_`` entries.  The password entries can also be omitted if a password
-is not needed.
+The password entries should be omitted if a password is not needed for database
+authentication.
+
+When tunnelling the connection, if a SSH keyfile is given in ``tunnel_identity``,
+that will be used to authenticate with the tunnel host.  If the other tunnelling
+parameters are given without ``tunnel_identity``, chimedb will attempt to use
+your SSH agent or look for look for local key files.  If no tunnel is required,
+omit the ``tunnel_`` entries.
 
 If none of the YAML files are found, the last thing tried is to import a
 Python module called ``chimedb.config``.  This module, if present, should
@@ -124,12 +128,11 @@ import os
 import logging
 import peewee as pw
 import pymysql
-import socket
 import sqlite3
 import yaml
-import sshtunnel
 import threading
 
+from . import tunnel
 from .exceptions import NoRouteToDatabase, ConnectionError
 
 # Globals
@@ -394,8 +397,6 @@ class MySQLConnector(BaseConnector):
         Filename of ssh private key to use to log into tunnel server.
     """
 
-    _tunnel = None
-
     def __init__(
         self,
         db,
@@ -415,7 +416,6 @@ class MySQLConnector(BaseConnector):
         self._host = host
         self._port = port
         self._tunnel_host = tunnel_host
-        self._tunnel_port = None
         self._tunnel_user = tunnel_user
         self._tunnel_identity = tunnel_identity
 
@@ -446,8 +446,6 @@ class MySQLConnector(BaseConnector):
                 connect_timeout=timeout,
             )
         except pymysql.err.OperationalError as e:
-            if self._tunnel is not None and self._tunnel.is_active:
-                self._tunnel.stop(force=True)
             raise ConnectionError(
                 f"Operational Error while connecting to database: {e}"
             ) from e
@@ -477,68 +475,46 @@ class MySQLConnector(BaseConnector):
     def description(self):
         out = "MySQL database at %s port %d" % (self._host, self._port)
         if self._tunnel_host:
-            out += " tunnelled through {0} to localhost".format(self._tunnel_host)
-            if self._tunnel_port is not None:
-                out += " port {0}".format(self._tunnel_port)
+            tunnel_port = tunnel.port()
+            if tunnel_port is not None:
+                out += f" tunnelled through {self._tunnel_host} to localhost port {tunnel_port}"
         return out
 
     def _host_port(self):
         if self._tunnel_host:
             host = _LOCALHOST
-            port = self._tunnel_port
+            port = tunnel.port()
         else:
             host = self._host
             port = self._port
         return host, port
 
     def ensure_route_to_database(self):
-        # Check if we need a tunnel and create one if need be.
-        if not self._tunnel_host or tunnel_active(self._tunnel_port):
+        """Check if we need a tunnel and create one if need be."""
+
+        # If we're not tunnelling, there's nothing to do
+        if not self._tunnel_host or not self._tunnel_user:
             return
 
         if not connect_this_rank():
+            return
+
+        # Is there already a tunnel running?
+        if tunnel.active():
             return
 
         # Abandon an existing database connection: if the tunnel isn't
         # active, presumably the connection isn't working
         self._database = None
 
-        _logger.debug(
-            "Attempting SSH tunnel to {0}:{1} through {2}".format(
-                self._host, self._port, self._tunnel_host
-            )
-        )
-
-        try:
-            self._tunnel = sshtunnel.SSHTunnelForwarder(
-                self._tunnel_host,
-                ssh_config_file=None,
-                remote_bind_address=(self._host, self._port),
-                local_bind_address=(_LOCALHOST,),
-                ssh_username=self._tunnel_user,
-                ssh_pkey=self._tunnel_identity,
-            )
-        except ValueError:
-            msg = "No authentication option for %s" % self._tunnel_host
-            raise NoRouteToDatabase(msg)
-
-        # Try to start and handle any exceptions
-        try:
-            self._tunnel.start()
-        except (
-            sshtunnel.BaseSSHTunnelForwarderError,
-            sshtunnel.HandlerSSHTunnelForwarderError,
+        # Start the tunnel
+        if not tunnel.start(
+            tunnel_host=self._tunnel_host,
+            remote_host=self._host,
+            remote_port=self._port,
+            tunnel_user=self._tunnel_user,
+            tunnel_identity=self._tunnel_identity,
         ):
-            msg = "Could not tunnel through {0}.".format(self._tunnel_host)
-            raise NoRouteToDatabase(msg)
-
-        # Get the bound port number
-        self._tunnel_port = self._tunnel.local_bind_address[1]
-
-        # Wait for the tunnel to be established
-        self._tunnel.skip_tunnel_checkup = False
-        self._tunnel.check_tunnels()  # This waits for the tunnel to come up
-        if not self._tunnel.tunnel_is_up[(_LOCALHOST, self._tunnel_port)]:
             raise ConnectionError("An error occurred while setting up the tunnel")
 
     def close(self):
@@ -547,10 +523,6 @@ class MySQLConnector(BaseConnector):
             _logger.debug("Closing database.")
             self._database.close()
             self._database = None
-        if self._tunnel is not None and self._tunnel.is_active:
-            _logger.debug("Stopping tunnel.")
-            self._tunnel.stop(force=True)
-            self._tunnel = None
 
 
 class SqliteConnector(BaseConnector):
@@ -610,24 +582,19 @@ class SqliteConnector(BaseConnector):
 
 
 def tunnel_active(tunnel_port):
-    """Returns true if a connection to local port <tunnel_port> succeeds"""
-    if tunnel_port is None:
-        return False
+    """Returns True if the DB tunnel is running.
 
-    sd = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    # Just added this to speed things up.  I think this is enough time. -KM
-    sd.settimeout(0.5)
-    try:
-        # Connect to the given tunnel_port on localhost.
-        sd.connect((_LOCALHOST, tunnel_port))
-    except socket.error:
-        return False
-    sd.close()
-    return True
+    Parameters
+    ----------
+    tunnel_port : Any
+        Ignored.
 
-
-def create_tunnel(*args, **kwargs):
-    raise NotImplementedError("Try using sshtunnel instead.")
+    Returns
+    -------
+    bool
+        True if the database tunnel is running.  False otherwise.
+    """
+    return tunnel.active()
 
 
 def connected_mysql(db):
@@ -814,3 +781,6 @@ def close():
     if current_connector_RW:
         current_connector_RW.close()
         _threadlocal.current_connector_RW = None
+
+    # Also stop the tunnel, if it's running
+    tunnel.stop()

--- a/chimedb/core/tunnel.py
+++ b/chimedb/core/tunnel.py
@@ -1,0 +1,242 @@
+"""Tunnelling SSH server.
+
+This provides the ConnectionTunnel thread which implements an
+SSH client which can tunnel a database port from another, remote host.
+"""
+
+import asyncio
+import os
+import logging
+import threading
+import time
+
+import asyncssh
+
+from .exceptions import NoRouteToDatabase
+
+_logger = logging.getLogger("chimedb")
+
+# We only ever run one tunnel thread.  This is it
+_thread = None
+
+# Mutex for _thread
+_thread_lock = threading.Lock()
+
+
+class ConnectionTunnel(threading.Thread):
+    """A SSH-tunnelling thread.
+
+    Attributes
+    ----------
+    tunnel_host : str
+        The host to tunnel through
+    tunnel_user : str
+        The username used to log into the tunnel host
+    tunnel_identity : Pathlike | None
+        If not None, a path to a SSH identity to use to authenticate with the
+        tunnel host.  If None, authentication will be attempted via SSH agent
+        and/or keys found locally.
+    remote_host : str
+        The remote host to tunnel
+    remote_port : int
+        The remote poirt to tunnel
+    """
+
+    def __init__(
+        self,
+        tunnel_host: str,
+        tunnel_user: str,
+        tunnel_identity: str | os.PathLike | None,
+        remote_host: str,
+        remote_port: int,
+    ) -> None:
+        # Connection and tunnel details
+        self._tunnel_host = tunnel_host
+        self._remote_host = remote_host
+        self._remote_port = remote_port
+
+        # Choose auth parameters based on whether we have been given an ident or not
+        if tunnel_identity:
+            auth_opts = {"client_keys": [tunnel_identity], "agent_path": None}
+        else:
+            # Use configuration defaults, in this case, which will try both an agent, and
+            # also look for local keys
+            auth_opts = {}
+
+        # Set SSH client options
+        self._ssh_opts = asyncssh.SSHClientConnectionOptions(
+            username=tunnel_user, **auth_opts
+        )
+
+        # This is set when the tunnel is active
+        self.tunnel_port = None
+
+        # Set to True to shut down the tunnel
+        self._stop_the_tunnel = False
+
+        # Thread init
+        super().__init__(name="ConnectionTunnel", daemon=True)
+
+    async def ssh_client(self):
+        """The SSH client that does the forwarding."""
+
+        try:
+            async with asyncssh.connect(
+                self._tunnel_host, options=self._ssh_opts
+            ) as conn:
+                # Bind the listener to an ephemeral port
+                listener = await conn.forward_local_port(
+                    "", 0, self._remote_host, self._remote_port
+                )
+
+                # Tunnel active: record port
+                self.tunnel_port = listener.get_port()
+
+                _logger.debug(
+                    f"SSH tunnel via {self._tunnel_host} established on port {self.tunnel_port}"
+                )
+
+                # Wait for termination
+                while not self._stop_the_tunnel:
+                    await asyncio.sleep(0.1)
+
+                # Close the connection
+                _logger.debug("Terminating tunnel: shutdown requested.")
+                listener.close()
+                await listener.wait_closed()
+        except asyncio.CancelledError:
+            _logger.debug(f"SSH tunnel via {self._tunnel_host} stopped")
+            raise
+        except asyncssh.misc.ConnectionLost as e:
+            _logger.warning(f"Connection to {self._tunnel_host} lost: {e}")
+            raise NoRouteToDatabase(f"Error in SSH tunnel: {e}") from e
+        except (OSError, asyncssh.Error) as e:
+            _logger.warning(f"SSH tunnel via {self._tunnel_host} aborted: {e}")
+            raise NoRouteToDatabase(f"Error in SSH tunnel: {e}") from e
+        finally:
+            # Tunnel no longer active
+            self.tunnel_port = None
+            self._stop_the_tunnel = False
+
+    def run(self):
+        """Tunnelling SSH server implementation."""
+
+        # Start the asyncio loop
+        asyncio.run(self.ssh_client())
+
+    def join(self):
+        """Terminate the tunnel."""
+
+        # Cancel the client, if running
+        _logger.debug("Joining...")
+        if self.tunnel_port:
+            self._stop_the_tunnel = True
+
+        # Join the thread
+        return super().join()
+
+
+def active() -> bool:
+    """Is the tunnel active?"""
+    global _thread, _thread_lock
+    with _thread_lock:
+        if _thread is None:
+            return False
+        if not _thread.is_alive():
+            return False
+        return _thread.tunnel_port is not None
+
+
+def port() -> int:
+    """Return the tunnel's local port number.
+
+    If the tunnel isn't running, this returns None.
+    """
+    with _thread_lock:
+        if _thread and _thread.is_alive():
+            return _thread.tunnel_port
+
+    return None
+
+
+def start(
+    tunnel_host: str,
+    tunnel_user: str,
+    tunnel_identity: str | os.PathLike | None,
+    remote_host: str,
+    remote_port: int,
+) -> bool:
+    """Start tunnelling.
+
+    Waits for the tunnel to be established, or for the ssh client to exit.
+
+    If a tunnel is already active, this does nothing.
+
+    Parameters
+    ----------
+    tunnel_host : str
+        The host to tunnel through
+    tunnel_user : str
+        The username used to log into the tunnel host
+    tunnel_identity : Pathlike | None
+        If not None, a path to a SSH identity to use to authenticate with the
+        tunnel host.  If None, authentication will be attempted via SSH agent
+        and/or keys found locally.
+    remote_host : str
+        The remote host to tunnel
+    remote_port : int
+        The remote port to tunnel
+
+    Returns
+    -------
+    bool
+        True if the tunnel successfully started.  False otherwise.
+    """
+    global _thread, _thread_lock
+
+    # Clean up a dead tunnel, if it's still around.
+    with _thread_lock:
+        if _thread is not None and not _thread.is_alive():
+            # Thread is done
+            _thread = None
+
+    # If the thread is not running, start it
+    with _thread_lock:
+        if _thread is None:
+            _logger.debug(
+                f"Attempting to tunnel through {tunnel_user}@{tunnel_host}..."
+            )
+            # Create new thread
+            _thread = ConnectionTunnel(
+                tunnel_host, tunnel_user, tunnel_identity, remote_host, remote_port
+            )
+
+            # Start it
+            _thread.start()
+
+    # Wait for the tunneling to start, or for the thread to exit
+    while True:
+        # Wait a bit
+        time.sleep(0.1)
+        with _thread_lock:
+            if not _thread:
+                # Someone else cleaned up while we were waiting
+                return False
+            if not _thread.is_alive():
+                # Thread is done
+                _thread = None
+                return False
+            if _thread.tunnel_port is not None:
+                # Tunnel is active
+                return True
+
+
+def stop() -> bool:
+    """Stop the tunnel, if active."""
+    global _thread, _thread_lock
+
+    with _thread_lock:
+        if _thread is not None:
+            while _thread.is_alive():
+                _thread.join()
+            _thread = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,9 @@ requires-python = ">=3.10"
 dynamic = ["readme", "version"]
 license = {file = "LICENSE"}
 dependencies = [
+    "asyncssh",
     "peewee >= 3.16.3",
     "pymysql",
-    "paramiko < 4",
-    "sshtunnel >= 0.4.0",
     "ujson",
     "PyYAML"
 ]

--- a/test/test_tunnel.py
+++ b/test/test_tunnel.py
@@ -1,0 +1,147 @@
+"""Test tunnelling."""
+
+import os
+import socket
+import subprocess
+import threading
+import time
+
+import pytest
+
+from chimedb.core import tunnel
+
+# Data from the "database"
+DATA = b"I'm a database server!"
+
+
+class TCPServer(threading.Thread):
+    """A very simple TCP server."""
+
+    def __init__(self):
+        # Port we're listening on.  Will be filled in when the server starts
+        self.port = None
+
+        # Set this to True to stop the server
+        self._shutdown = False
+
+        super().__init__(name="TCPServer", daemon=True)
+
+    def shutdown(self):
+        self._shutdown = True
+
+    def run(self):
+        # Create a TCP socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        # Set timeout
+        sock.settimeout(1)
+
+        # Bind
+        sock.bind(("127.0.0.1", 0))
+
+        # Get bound port number
+        self.port = sock.getsockname()[1]
+
+        # Listen
+        sock.listen(1)
+
+        # Pretend to be a database server
+        while not self._shutdown:
+            try:
+                conn, peer = sock.accept()
+            except TimeoutError:
+                continue
+
+            try:
+                conn.send(DATA)
+            finally:
+                conn.close()
+
+        # Shutdown
+        self.port = None
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            # Socket not connected
+            pass
+
+        sock.close()
+
+
+@pytest.fixture
+def fake_dbms():
+    """Create a fake database server that we can tunnel.
+
+    Yields the port on which the server is listening.
+    """
+
+    # Start database thread
+    db = TCPServer()
+
+    db.start()
+
+    # Wait for start
+    while db.is_alive() and db.port is None:
+        time.sleep(0.1)
+
+    # Run the test
+    yield db.port
+
+    # Shutdown
+    db.shutdown()
+    while db.is_alive():
+        db.join()
+
+
+@pytest.fixture
+def stop_tunnel():
+    """Ensure tunnels stop after a test."""
+
+    # Run the test
+    yield
+
+    # If no tunnel is running, this is a NOP
+    tunnel.stop()
+
+
+def test_tunnel(fake_dbms, stop_tunnel):
+    """Test tunnelling."""
+
+    # Only run this test is we can SSH to localhost
+    result = subprocess.run(
+        ["ssh", "-o", "BatchMode=yes", "127.0.0.1", "echo This worked."],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode or result.stdout != "This worked.\n":
+        pytest.skip("Can't SSH to localhost")
+
+    tunnel.start(
+        tunnel_host="127.0.0.1",
+        tunnel_user=os.getlogin(),
+        tunnel_identity=None,
+        remote_host="127.0.0.1",
+        remote_port=fake_dbms,
+    )
+
+    # Port is set
+    port = tunnel.port()
+    assert port is not None
+
+    # Read data
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(("127.0.0.1", port))
+    assert sock.recv(len(DATA)) == DATA
+    sock.close()
+
+    # Stop the tunnel
+    tunnel.stop()
+
+    # No tunnel port anymore
+    assert tunnel.port() is None
+
+    # We should be able to do this again
+    tunnel.stop()
+
+    # Still no tunnel
+    assert tunnel.port() is None

--- a/test/test_tunnel.py
+++ b/test/test_tunnel.py
@@ -114,11 +114,11 @@ def test_tunnel(fake_dbms, stop_tunnel):
         text=True,
     )
     if result.returncode or result.stdout != "This worked.\n":
-        pytest.skip("Can't SSH to localhost")
+        pytest.skip(f"Can't SSH to localhost: {result.stdout} / {result.stderr}")
 
     tunnel.start(
         tunnel_host="127.0.0.1",
-        tunnel_user=os.getlogin(),
+        tunnel_user=os.environ["USER"],
         tunnel_identity=None,
         remote_host="127.0.0.1",
         remote_port=fake_dbms,


### PR DESCRIPTION
This removes the dependency on SSHTunnel (which I don't think is being updated anymore) and replaces it with a tunnel implementation based on the `asyncssh` library.  (I think this also removes the dependency on `paramiko`.)

Like SSHTunnel did, `asyncssh` does all the tunnel management for us. All that's left for us to do, which we didn't have to do with SSHTunnel, is manage the thread that the tunnelling SSH client runs in.

Tunnel management has been removed from MySQLConnector and put in its own module, `chimedb.core.tunnel`.

Closes #53